### PR TITLE
Change operator-linebreak rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ module.exports = {
 		'object-curly-spacing': 0,
 		'one-var': 0,
 		'operator-assignment': 0,
-		'operator-linebreak': [1, 'before'],
+		'operator-linebreak': [1, 'after'],
 		'padded-blocks': 0,
 		'quote-props': 0,
 		'quotes': [1, 'single', 'avoid-escape'],


### PR DESCRIPTION
For inline conditionals, the `before` rule is odd looking. We could add an override for the logical operators if we have examples where `before` is better in other cases.

Example with updated rule

```
    let transform = orientation === 'top' && 'translateY(' + -p + '%)' ||
                    orientation === 'bottom' && 'translateY(' + p + '%)' ||
                    orientation === 'left' && 'translateX(' + -p + '%)' ||
                    orientation === 'right' && 'translateX(' + p + '%)';
```

vs current rule

```
    let transform = orientation === 'top' && 'translateY(' + -p + '%)'
                    || orientation === 'bottom' && 'translateY(' + p + '%)'
                    || orientation === 'left' && 'translateX(' + -p + '%)'
                    || orientation === 'right' && 'translateX(' + p + '%)';
```

Or

```
if (
    aReallyLongConditionThatCausesALineBreak ||
    aSecondCondition
) {
    // logic
}
```

vs

```
if (
    aReallyLongConditionThatCausesALineBreak
    || aSecondCondition
) {
    // logic
}
```
