### PR TITLE
Adds additional environments, to reduce explicit global declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 module.exports = {
 	globals: {
 		'__DEV__': true,
+		'document': true,
 		'expect': true,
 		'module': true,
-		'require': true
+		'require': true,
+		'window': true
 	},
 	env: {
-		'browser': true,
 		'es6': true, // sets the "ecmaVersion" parser option to 6
 		'mocha': true
 	},


### PR DESCRIPTION
Added the `es6` environment to cover the use of ES6 globals. Note that the "es6" environment automatically sets the parser option for `ecmaVersion` to 6.

Considered adding the `commonjs` environment (to cover the "require" and "module" globals), but decided there was too much indirection.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
