### PR TITLE
Adds ES6 environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,12 @@ module.exports = {
 		'it': true,
 		'expect': true
 	},
+	env: {
+		'es6': true // sets the "ecmaVersion" parser option to 6
+	},
 	extends: ['eslint:recommended', 'plugin:react/recommended'],
 	parser: 'babel-eslint',
 	parserOptions: {
-		'ecmaVersion': 6,
 		'sourceType': 'module',
 		'ecmaFeatures': {
 			'jsx': true


### PR DESCRIPTION
Added the `es6` environment to cover the use of ES6 globals. Note that the "es6" environment automatically sets the parser option for `ecmaVersion` to 6.

Considered adding the `commonjs` environment (to cover the "require" and "module" globals), but decided there was too much indirection.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
