### PR TITLE
ENYO-5814: Add eslint-jest-plugin for strict mode to check focused tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information (including editor/IDE setup), please see the [docs](docs/in
 `eslint-config-enact` can be installed locally or globally.  The following command will install the config and all its dependencies globally:
 
 ```bash
-npm install -g eslint eslint-plugin-react eslint-plugin-babel babel-eslint eslint-plugin-enact eslint-config-enact
+npm install -g eslint eslint-plugin-react eslint-plugin-babel babel-eslint eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 >**NOTE**: Using the [`cli` tools](https://github.com/enactjs/cli/) to create your projects eliminates the need to globally install these dependencies unless you wish editor integration.

--- a/strict.js
+++ b/strict.js
@@ -4,6 +4,7 @@ module.exports = {
 	plugins: [
 		'react',
 		'babel',
+		'jest',
 		'enact'
 	],
 	rules: {
@@ -99,6 +100,9 @@ module.exports = {
 
 		// babel plugin
 		'babel/object-curly-spacing': [1, 'never'],
+
+		// jest plugin
+		'jest/no-focused-tests': 'error',
 
 		// enact plugin
 		'enact/display-name': 1,


### PR DESCRIPTION
enact framework code should not ship any tests with `only` and error in our Travis CI. `eslint-jest-plugin` has a `no-focused-tests` rule to check these type of tests.

See https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-focused-tests.md for more details about the rule.

Note that this is only applied for `strict` mode. The intention is to check our framework code unit tests for now, but we may adopt jest's recommended rules in the future if we want to.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>