### PR TITLE
PLAT-74820: Update ESLint config for new lint rule no-self-assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ module.exports = {
 		'no-redeclare': [2, {'builtinGlobals': true}],
 		'no-return-assign': [1, 'except-parens'],
 		'no-script-url': 2,
+		'no-self-assign': 1,
 		'no-self-compare': 2,
 		'no-sequences': 1,
 		'no-throw-literal': 2,

--- a/strict.js
+++ b/strict.js
@@ -24,6 +24,7 @@ module.exports = {
 		'no-new-wrappers': 2,
 		'no-new': 1,
 		'no-return-assign': [2, 'except-parens'],
+		'no-self-assign': 2,
 		'no-sequences': 2,
 		'no-useless-call': 2,
 		'no-useless-escape': 1,


### PR DESCRIPTION
For the new `no-self-assign` rule, a self assign is not a direct syntax error, however still worth a warning.  For strict, it should trigger an error though.

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>