### PR TITLE
PLAT-76285: Enhanced React Hooks support in tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact eslint config:
 
+## [unreleased]
+
+* Added `react-hooks/exhaustive-deps` warning
+* Added `react-hooks/rules-of-hooks` error
+
 ## [1.4.1]
 
 * Strict: Added `jest/no-focused-tests` error

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information (including editor/IDE setup), please see the [docs](docs/in
 `eslint-config-enact` can be installed locally or globally.  The following command will install the config and all its dependencies globally:
 
 ```bash
-npm install -g eslint eslint-plugin-react eslint-plugin-babel babel-eslint eslint-plugin-jest eslint-plugin-enact eslint-config-enact
+npm install -g eslint eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel babel-eslint eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 >**NOTE**: Using the [`cli` tools](https://github.com/enactjs/cli/) to create your projects eliminates the need to globally install these dependencies unless you wish editor integration.

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
 	},
 	plugins: [
 		'react',
+		'react-hooks',
 		'babel',
 		'enact'
 	],
@@ -280,6 +281,10 @@ module.exports = {
 		'react/jsx-uses-react': 1,
 		'react/jsx-uses-vars': 1,
 		'react/jsx-wrap-multilines': 0,
+
+		// react-hooks plugin
+		'react-hooks/exhaustive-deps': 1,
+		'react-hooks/rules-of-hooks': 2,
 
 		// enact plugin
 		'enact/no-module-exports-import': 2

--- a/package.json
+++ b/package.json
@@ -11,5 +11,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/enactjs/eslint-config-enact.git"
+  },
+  "peerDependencies": {
+    "babel-eslint": "10.x",
+    "eslint": "5.x",
+    "eslint-plugin-babel": "5.x",
+    "eslint-plugin-enact": "0.1.x",
+    "eslint-plugin-jest": "22.x",
+    "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "1.x"
   }
 }


### PR DESCRIPTION
Adds the `react-hooks/exhaustive-deps` warning and `react-hooks/rules-of-hooks` error rules.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>