### PR TITLE
WRO-8722: Update in-editor linting guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 node_js:
     - "node"

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ If you are not using the `cli` tools, you can create (or modify) an `.eslintrc` 
 
 ```json
 {
-  "extends": "enact"
+  "extends": "enact-proxy"
 }
 ```
 >**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,5 +132,5 @@ If in-editor linting is not working in your local project, be sure you set up `p
 Or, please use an additional setting(ex: eslint.nodePath) for your editor if an installed ESLint package can't be detected.
 
 ```sh
-/myGlobalNodePackages/node_modules.
+/myGlobalNodePackages/node_modules
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,20 +53,16 @@ Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
 
-```sh
-npm install eslint-config-enact-proxy
-```
-
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh
-npm install --location=global eslint @enact/cli
+npm install -g eslint
 ```
 
 Then, you will need to uninstall any previous globally-installed Enact linting package (everything but eslint itself):
 
 ```sh
-npm remove --location=global eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
+npm uninstall -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 Each editor requires a slightly different setup.  Jump to the section relevant to your editor.
@@ -110,15 +106,6 @@ Unfortunately, Syntastic does not support real-time linting and only lints on sa
 ##### Visual Studio Code
 
 Install the [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) plugin.  More information on linters and Visual Studio Code can be found [here](https://code.visualstudio.com/docs/languages/javascript#_linters).
-
-> **NOTE**: To open the Settings editor, use the following VS Code menu command:
-
-```sh
-On Windows/Linux - File > Preferences > Settings
-On macOS - Code > Preferences > Settings
-```
-
-This extension contributes the following variables to the settings: [Settings Options](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#settings-options)
 
 ##### WebStorm
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,20 +15,28 @@ If you use the `cli` tools to create your project, `npm run lint` will run the E
 If you want to switch to the strict version of the linting rules, modify your `package.json` file and change the following lines:
 
 ```json
-    "lint": "enact lint"
+    "lint": "enact lint",
+...
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
 ```
 
 to read:
 
 ```json
-    "lint": "enact lint --strict"
+    "lint": "enact lint --strict",
+...
+  "eslintConfig": {
+    "extends": "enact-proxy/strict"
+  },
 ```
 
-If you are not using the `cli` tools, you can create (or modify) an `.eslintrc` in the project's root and run `eslint .`(`eslint-config-enact-proxy` should be installed locally on a project.):
+If you are not using the `cli` tools, you can create (or modify) an `.eslintrc` in the project's root and run `eslint .`:
 
 ```json
 {
-  "extends": "enact-proxy"
+  "extends": "enact"
 }
 ```
 >**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.
@@ -44,11 +52,20 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
-In order for in-editor linting, `eslint-config-enact-proxy` should be installed locally on a project:
+`eslint-config-enact-proxy` needs to be installed locally on a project to enable in-editor linting:
 
 ```sh
 npm install --save-dev eslint-config-enact-proxy
 ```
+
+Also, you need to modify `eslintConfig` property in `package.json`:
+
+```json
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
+```
+>**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.
 
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,16 +52,21 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
+
+```sh
+npm install eslint-config-enact-proxy
+```
+
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh
-npm install -g eslint
+npm install --location=global eslint
 ```
 
 Then, you will need to uninstall any previous globally-installed Enact linting package (everything but eslint itself):
 
 ```sh
-npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
+npm remove --location=global eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 Each editor requires a slightly different setup.  Jump to the section relevant to your editor.
@@ -106,6 +111,15 @@ Unfortunately, Syntastic does not support real-time linting and only lints on sa
 
 Install the [vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) plugin.  More information on linters and Visual Studio Code can be found [here](https://code.visualstudio.com/docs/languages/javascript#_linters).
 
+> **NOTE**: To open the Settings editor, use the following VS Code menu command:
+
+```sh
+On Windows/Linux - File > Preferences > Settings
+On macOS - Code > Preferences > Settings
+```
+
+This extension contributes the following variables to the settings: [Settings Options](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#settings-options)
+
 ##### WebStorm
 
 In either the default or per-project preferences, go to *Languages & Frameworks* > *JavaScript* > *Code Quality* > *ESLint*.
@@ -114,3 +128,9 @@ Check the *Enable* checkbox.  Ensure that the proper paths for `node` and `eslin
 #### Troubleshooting
 
 If in-editor linting is not working in your local project, be sure you set up `package.json` or `.eslintrc` as described above.
+
+Or, please use an additional setting for your editor if an installed ESLint package can't be detected.
+
+```sh
+/myGlobalNodePackages/node_modules.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,7 +129,7 @@ Check the *Enable* checkbox.  Ensure that the proper paths for `node` and `eslin
 
 If in-editor linting is not working in your local project, be sure you set up `package.json` or `.eslintrc` as described above.
 
-Or, please use an additional setting for your editor if an installed ESLint package can't be detected.
+Or, please use an additional setting(ex: eslint.nodePath) for your editor if an installed ESLint package can't be detected.
 
 ```sh
 /myGlobalNodePackages/node_modules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,28 +15,20 @@ If you use the `cli` tools to create your project, `npm run lint` will run the E
 If you want to switch to the strict version of the linting rules, modify your `package.json` file and change the following lines:
 
 ```json
-    "lint": "enact lint",
-...
-  "eslintConfig": {
-    "extends": "enact-proxy"
-  },
+    "lint": "enact lint"
 ```
 
 to read:
 
 ```json
-    "lint": "enact lint --strict",
-...
-  "eslintConfig": {
-    "extends": "enact-proxy/strict"
-  },
+    "lint": "enact lint --strict"
 ```
 
-If you are not using the `cli` tools, you can create (or modify) an `.eslintrc` in the project's root and run `eslint .`:
+If you are not using the `cli` tools, you can create (or modify) an `.eslintrc` in the project's root and run `eslint .`(`eslint-config-enact-proxy` should be installed locally on a project.):
 
 ```json
 {
-  "extends": "enact"
+  "extends": "enact-proxy"
 }
 ```
 >**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.
@@ -52,6 +44,12 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
+In order for in-editor linting, `eslint-config-enact-proxy` should be installed locally on a project:
+
+```sh
+npm install --save-dev eslint-config-enact-proxy
+```
+
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh
@@ -114,9 +112,3 @@ Check the *Enable* checkbox.  Ensure that the proper paths for `node` and `eslin
 #### Troubleshooting
 
 If in-editor linting is not working in your local project, be sure you set up `package.json` or `.eslintrc` as described above.
-
-Or, please use an additional setting(ex: eslint.nodePath) for your editor if an installed ESLint package can't be detected.
-
-```sh
-/myGlobalNodePackages/node_modules
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ npm install eslint-config-enact-proxy
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh
-npm install --location=global eslint
+npm install --location=global eslint @enact/cli
 ```
 
 Then, you will need to uninstall any previous globally-installed Enact linting package (everything but eslint itself):

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,6 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
-
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Enact CLI supports in-editor linting by installing the 'eslint-config-enact-proxy' module locally.
But for ease to use, we need to guide users more kindly and in detail.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add a guide for installing `eslint-config-enact-proxy`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Change `remove` to `uninstall` when deleting globally-installed packages
- Update .travis.yml to solve the travis error
    - ubuntu 20 is required for node 18 ( https://docs.travis-ci.com/user/reference/focal/)


### Links
[//]: # (Related issues, references)
WRO-8722

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong(taeyoung.hong@lge.com)