### PR TITLE
WRP-13212: Add ENACT_PACK_NO_ANIMTAION as a global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact eslint config:
 
+## unreleased
+
+* Fixed support for `ENACT_PACK_NO_ANIMATION` global
+
 ## [4.1.5] (May 17, 2023)
 
 * Updated all dependencies to the latest.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ module.exports = {
 		__DEV__: true,
 		process: true,
 		window: true,
-		document: true
+		document: true,
+		ENACT_PACK_NO_ANIMATION: true
 	},
 	env: {
 		es6: true, // Enables ES6 globals


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As we added `ENACT_PACK_NO_ANIMATION` global variable when building enact apps from WRP-11042 to turn off animations, we need to let eslint know about the variable.

When using `ENACT_PACK_NO_ANIMATION` variable from the theme library, an eslint error should occur like the one below.
> 'ENACT_PACK_NO_ANIMTAION' is not defined  no-undef

I guess we could suppress the error by updating eslint rules to add the global variables to the config guided here(https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files-1) instead of using /* global */ escape.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `ENACT_PACK_NO_ANIMATION` to globals in the config

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-13212

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)