### PR TITLE
disable eslint no-shadow, use @typescript-eslint/no-shadow

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,8 @@ module.exports = {
 				'@typescript-eslint/consistent-type-assertions': 'warn',
 				'no-array-constructor': 'off',
 				'@typescript-eslint/no-array-constructor': 'warn',
+				'no-shadow': 'off',
+				'@typescript-eslint/no-shadow': 'warn',
 				'no-use-before-define': 'off',
 				'@typescript-eslint/no-use-before-define': ['warn', {
 					functions: false,


### PR DESCRIPTION
- Prevents typescript enums from reporting false positives for shadowing
- see https://github.com/typescript-eslint/typescript-eslint/issues/2483

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

False positives were being detected by eslint when using enums, see https://github.com/typescript-eslint/typescript-eslint/issues/2483

### Resolution
[//]: # (Does the code work as intended?)


### Additional Considerations
[//]: # (How should the change be tested?)
Add an enum to any typescript file processed by enact, and see that it no longer warns.


### Links
[//]: # (Related issues, references)
https://github.com/typescript-eslint/typescript-eslint/issues/2483

### Comments
