### PR TITLE
WRQ-214: Support web-worker global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact eslint config:
 
+## unreleased
+
+* Added `worker` environment.
+
 ## [4.2.0] (January 3, 2024)
 
 * Added `@rushstack/eslint-patch` to support eslint shareable config.

--- a/index.js
+++ b/index.js
@@ -97,7 +97,10 @@ module.exports = {
 			builtinGlobals: true,
 			hoist: 'all',
 			allow: [
-				'context'
+				'context',
+				'location',
+				'name',
+				'Notification'
 			]
 		}],
 		'no-throw-literal': 'error',

--- a/index.js
+++ b/index.js
@@ -97,10 +97,7 @@ module.exports = {
 			builtinGlobals: true,
 			hoist: 'all',
 			allow: [
-				'context',
-				'location',
-				'name',
-				'Notification'
+				'context'
 			]
 		}],
 		'no-throw-literal': 'error',

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
 		ENACT_PACK_NO_ANIMATION: true
 	},
 	env: {
+		worker: true,
 		es6: true, // Enables ES6 globals
 		'shared-node-browser': true, // restrict to common globals to preserve isomorphic support
 		commonjs: true

--- a/strict.js
+++ b/strict.js
@@ -59,7 +59,10 @@ module.exports = {
 			builtinGlobals: true,
 			hoist: 'all',
 			allow: [
-				'context'
+				'context',
+				'location',
+				'name',
+				'Notification'
 			]
 		}],
 		'no-undefined': 'error',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In order to provide the global variable of the `web-worker`, the environment must be added to the `env` setting in the config file.
An environment provides predefined global variables.
- `env`: https://eslint.org/docs/latest/use/configure/language-options#specifying-environments
  - global variables in `env`: https://github.com/sindresorhus/globals/blob/main/globals.json

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Support web-worker global variables

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Allow `location`, `name`, and `Notification` on the `no-shadow` rule in `strict.js`.

The `eslint-config-enact` uses the `no-shadow` rule with the `builtinGlobals: true` option to prevent defining the same names with global variables in classes, functions, etc.
But to avoid lint errors, those 3 variable names are needed to be allowed.
Reference: https://eslint.org/docs/latest/rules/no-shadow

### Links
[//]: # (Related issues, references)
WRQ-214

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)