### PR TITLE
WRR-1011: Fixed `eslint` and `prettier` lint rules to not conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact eslint config:
 
+## [unreleased]
+
+* Updated `@stylistic/js/space-before-function-paren` rule to fix conflicts with `prettier` rules.
+
 ## [5.0.0-alpha.2] (December 6, 2024)
 
 * Replaced deprecated rule `no-new-object` with `no-object-constructor`.

--- a/strict.js
+++ b/strict.js
@@ -81,7 +81,14 @@ module.exports = {
 		'@stylistic/js/linebreak-style': ['warn', 'unix'],
 		'@stylistic/js/operator-linebreak': ['warn', 'after'],
 		'@stylistic/js/space-before-blocks': ['warn', 'always'],
-		'@stylistic/js/space-before-function-paren': ['warn', 'always'],
+		'@stylistic/js/space-before-function-paren': [
+			'warn',
+			{
+				anonymous: 'always',
+				named: 'never',
+				asyncArrow: 'always'
+			}
+		],
 		'@stylistic/js/space-infix-ops': ['warn', {
 			int32Hint: true
 		}],


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
An issue has been signaled in storybook-utils repo. The `eslint` rules and `prettier` lint rules are opposite for applying spacing after function keyword. Currently a workaround was applied to avoid the conflicts.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I have adjusted '@stylistic/js/space-before-function-paren' rule to avoid conflicts with `prettier` rules.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-1011

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop (stanca.pop@lgepartner.com)