### PR TITLE
WRR-23385: Remove 'enact/prop-types' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact eslint config:
 
+## unreleased
+
+* Removed deprecated rule `enact/prop-types`.
+
 ## [5.0.0-alpha.5] (February 21, 2025)
 
 * Updated `eslint` to v9 and adopted flat config.

--- a/strict.js
+++ b/strict.js
@@ -192,9 +192,7 @@ module.exports = [
 			}, {
 				"object": "it",
 				"property": "only"
-			}],
-			// PropType validation is not a priority in tests
-			'enact/prop-types': 'off'
+			}]
 		}
 	}
 ];

--- a/strict.js
+++ b/strict.js
@@ -152,8 +152,7 @@ module.exports = [
 
 			// enact plugin https://github.com/enactjs/eslint-plugin-enact/
 			'enact/display-name': 'warn',
-			'enact/kind-name': 'warn',
-			'enact/prop-types': ['warn', {'ignore': ['children', 'className', 'style']}]
+			'enact/kind-name': 'warn'
 		}
 	},
 	{


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://ko.react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis 
PropTypes were deprecated in April 2017 (v15.5.0).
However, the `enact/prop-types` rule still exists, so removing PropType causes a linting error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove 'enact/prop-types' rule

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-23385

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)