### PR TITLE
WRR-22888: Remove eslint-related configs in package.json

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./index');

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "ESLint config for Enact",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint . --no-config-lookup",
-    "fix": "eslint . --fix --no-config-lookup"
+    "lint": "eslint .",
+    "fix": "eslint . --fix"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -15,9 +15,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/enactjs/eslint-config-enact.git"
-  },
-  "eslintConfig": {
-    "extends": "./index.js"
   },
   "peerDependencies": {
     "eslint": "^9.20.0"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We have already implemented eslint 9, and going forward, configs other than eslint.config.js (eslintrc files, eslintignore files, package.json, etc.) will no longer work.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove eslint-related configs in package.json

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Add `eslint.config.js` to apply lint rules

### Links
[//]: # (Related issues, references)
WRR-22888

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)